### PR TITLE
Adding MDS and an example Pod to mount the resulting filesystem.

### DIFF
--- a/examples/kubernetes/ceph-mds-v1-rc.yaml
+++ b/examples/kubernetes/ceph-mds-v1-rc.yaml
@@ -1,20 +1,21 @@
 ---
-kind: DaemonSet
-apiVersion: extensions/v1beta1
+kind: ReplicationController
+apiVersion: v1
 metadata:
   labels:
     app: ceph
-    daemon: mon
-  name: ceph-mon
+    daemon: mds 
+  name: ceph-mds
   namespace: ceph
 spec:
+  replicas: 1
   template:
     metadata:
-      name: ceph-mon
+      name: ceph-mds
       namespace: ceph
       labels:
         app: ceph
-        daemon: mon
+        daemon: mds
     spec:
       nodeSelector:
         node-type: storage
@@ -36,26 +37,15 @@ spec:
         - name: ceph-mon
           image: quay.io/cornelius/ceph-daemon:latest
 #         image: quay.io/acaleph/ceph-daemon:kubernetes
-#          imagePullPolicy: Always
-          lifecycle:
-            preStop:
-                exec:
-                  # remove the mon on Pod stop.
-                  command:
-                    - "/remove-mon.sh"
           ports:
-            - containerPort: 6789
+            - containerPort: 6800
           env:
             - name: CEPH_DAEMON
-              value: MON
-            - name: CEPH_PUBLIC_NETWORK
-              value: 10.1.0.0/16
-            - name: CEPH_CLUSTER_NETWORK
-              value: 10.1.0.0/16
+              value: MDS
+            - name: CEPHFS_CREATE
+              value: "1"
             - name: KV_TYPE
               value: k8s
-            - name: MON_IP_AUTO_DETECT
-              value: "1"
             - name: CLUSTER
               value: ceph
           volumeMounts:
@@ -69,10 +59,10 @@ spec:
               mountPath: /var/lib/ceph/bootstrap-rgw
           livenessProbe:
               tcpSocket:
-                port: 6789
+                port: 6800
               initialDelaySeconds: 60
               timeoutSeconds: 5
           readinessProbe:
               tcpSocket:
-                port: 6789
+                port: 6800
               timeoutSeconds: 5

--- a/examples/kubernetes/ceph-mount-test.yaml
+++ b/examples/kubernetes/ceph-mount-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ceph-mount-test
+spec:
+  nodeSelector:
+    cephtest: "true"
+  containers:
+  - name: cephfs-rw
+    image: nginx
+    volumeMounts:
+    - mountPath: "/mnt/cephfs"
+      name: cephfs
+  volumes:
+  - name: cephfs
+    cephfs:
+      monitors:
+#This only works if you have skyDNS resolveable from the kubernetes node. Otherwise you must manually put in a mon-ip.
+      - ceph-mon.ceph:6789
+      user: admin
+      secretRef:
+        name: ceph-client-key

--- a/examples/kubernetes/generator/README.md
+++ b/examples/kubernetes/generator/README.md
@@ -52,5 +52,6 @@ kubectl create -f combined.yaml --namespace=ceph
 kubectl create -f bootstrap-osd.yaml --namespace=ceph
 kubectl create -f bootstrap-mds.yaml --namespace=ceph
 kubectl create -f bootstrap-rgw.yaml --namespace=ceph
+kubectl create secret generic ceph-client-key --from-file=ceph-client-key --namespace=ceph
 
 ```

--- a/examples/kubernetes/generator/generate_secrets.sh
+++ b/examples/kubernetes/generator/generate_secrets.sh
@@ -45,6 +45,7 @@ gen-combined-conf() {
   key=$(python ceph-key.py)
   keyring=$(sigil -f templates/ceph/admin.keyring.tmpl "key=${key}")
   ceph_admin_keyring_val=$(echo "${keyring}" | base64 | tr -d '\r\n')
+  echo "${key}" > ceph-client-key
 
   key=$(python ceph-key.py)
   keyring=$(sigil -f templates/ceph/mon.keyring.tmpl "key=${key}")


### PR DESCRIPTION
This is rough, but is enough to talk about.

This resulted in a working ceph cluster that I could mount back into a k8s pod.

Also some improvements can be had by using `--from-file` flag for secrets (see the ceph-client-key in README.md and generate_secrets.sh) If you like the approach I can refactor the rest of the secrets generation.
