### PR TITLE
Updating documentation regarding k8s network configuration.

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -20,6 +20,17 @@ We will be working on making this setup more agnostic, especially in regards to 
 
 # Tutorial
 
+### Override the default network settings
+
+By default, 10.244.0.0/16 is used for the `cluster_network` and `public_network` in ceph.conf. To change these defaults, set the following environment variables according to your network requirements. These IPs should be set according to the range of your Pod IPs in your kubernetes cluster:
+
+```
+export osd_cluster_network=192.168.0.0/16
+export osd_public_network=192.168.0.0/16
+```
+
+These will be picked up by sigil when generating the kubernetes secrets in the next section.
+
 ### Generate keys and configuration
 
 Run the following commands to generate the required configuration and keys.
@@ -50,7 +61,7 @@ kubectl create \
 -f ceph-mds-v1-dp.yaml \
 -f ceph-mon-v1-svc.yaml \
 -f ceph-mon-v1-ds.yaml \
--f ceph-mon-check-v1-rc.yaml \
+-f ceph-mon-check-v1-dp.yaml \
 -f ceph-osd-v1-ds.yaml \
 --namespace=ceph
 ```
@@ -178,4 +189,3 @@ kubectl exec -it --namespace=ceph ceph-rbd-test -- df -h
 
 By default `emptyDir` is used for everything. If you have durable storage on your nodes, replace the emptyDirs with a `hostPath` to that storage.
 
-Also, 10.244.0.0/16 is used for the default network settings, change these in the Kubernetes yaml objects and the sigil templates to reflect your network.

--- a/examples/kubernetes/ceph-mon-check-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mon-check-v1-dp.yaml
@@ -41,10 +41,6 @@ spec:
           env:
             - name: CEPH_DAEMON
               value: MON_HEALTH
-            - name: CEPH_PUBLIC_NETWORK
-              value: 10.244.0.0/16
-            - name: CEPH_CLUSTER_NETWORK
-              value: 10.244.0.0/16
             - name: KV_TYPE
               value: k8s
             - name: MON_IP_AUTO_DETECT

--- a/examples/kubernetes/ceph-mon-v1-ds.yaml
+++ b/examples/kubernetes/ceph-mon-v1-ds.yaml
@@ -48,10 +48,6 @@ spec:
           env:
             - name: CEPH_DAEMON
               value: MON
-            - name: CEPH_PUBLIC_NETWORK
-              value: 10.244.0.0/16
-            - name: CEPH_CLUSTER_NETWORK
-              value: 10.244.0.0/16
             - name: KV_TYPE
               value: k8s
             - name: MON_IP_AUTO_DETECT


### PR DESCRIPTION
Also deleted superflous environment variables.

Couple of notes while messing with this:

I think this whole thing can be flipped on its head in regards to the ceph.conf. Sigil could be put inside the container itself and generate configs based on ConfigMaps passed in via ENVs.

Going further: https://github.com/kelseyhightower/confd/issues/442

This would eliminate the need of installing anything special on the client machine, and make this truly painless.

The next sticking point is the configuration for `osd_cluster_network` and `osd_public_network`

If there isn't anything to do upstream, I think we can detect it by adding up all the `podCIDR` fields in the node objects for most setups, and the first `InternalIP` for net=host. Beyond that people will have to configure their networks manually.
